### PR TITLE
Using yaml.load is Dangerous for Untrusted Input

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ default_yaml = """
 
 def getOutput(y, type) :
     try :
-        objects = yaml.load(y)
+        objects = yaml.safe_load(y)
         if type == "python" :
             return pprint.pformat(objects)
         elif type == "canonical_yaml" :


### PR DESCRIPTION
Fixed a [server-side injection vulnerability](http://pyyaml.org/wiki/PyYAMLDocumentation#LoadingYAML).

I haven't tested this (I don't have an appspot account to do it with), but as it stands, I can construct Python objects with your webapp.
