### PR TITLE
Set CodeMirror minimum height property

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
       .CodeMirror {
         border: 1px solid #aaa;
         height: auto;
-        min-height: 350px;
         margin-bottom: 10px;
         font-family: monospace;
         text-align: left;
@@ -185,6 +184,9 @@
         }
       }
     });
+
+    // Set minimum height using CodeMirror API
+    editor.setSize(null, "350px");
 
     var submit = function() {
       $("#yaml_form").submit();


### PR DESCRIPTION
Replace CSS min-height property with editor.setSize() method to set the CodeMirror editor's minimum height of 350px using the proper CodeMirror API rather than CSS.