### PR TITLE
Clarify output box is not editable

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,14 @@
       .error {
         color: #f00;
       }
+      /* Style for read-only output editor */
+      .CodeMirror-readonly {
+        background-color: #f5f5f5;
+        cursor: default;
+      }
+      .CodeMirror-readonly .CodeMirror-cursor {
+        display: none;
+      }
     </style>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -135,7 +143,7 @@
       </div>
       <div id="right">
         <div class="code">
-          <h2>Output</h2>
+          <h2>Output <span style="font-size: 0.7em; color: #666;">(Read-only)</span></h2>
           <textarea id="output">{{ output|escape }}</textarea>
         </div>
       </div>
@@ -189,8 +197,12 @@
       lineNumbers: true,
       lineWrapping: true,
       readOnly: true,
-      viewportMargin: Infinity
+      viewportMargin: Infinity,
+      cursorBlinkRate: -1 // Hide cursor to indicate read-only
     });
+
+    // Add read-only class for visual styling
+    outputEditor.getWrapperElement().classList.add('CodeMirror-readonly');
 
     var submit = function() {
       $("#yaml_form").submit();


### PR DESCRIPTION
Added visual and textual indicators that the output box is not editable:
- Added gray background (#f5f5f5) and default cursor to output editor
- Added "(Read-only)" label to Output heading
- Hidden cursor in output CodeMirror editor
- Applied CodeMirror-readonly CSS class for consistent styling